### PR TITLE
Fix paths to reference docs for link and spellcheck.

### DIFF
--- a/doc/.sphinx/spellingcheck.yaml
+++ b/doc/.sphinx/spellingcheck.yaml
@@ -9,7 +9,7 @@ matrix:
     - .custom_wordlist.txt
     output: .sphinx/.wordlist.dic
   sources:
-  - _build/**/*.html|!_build/genindex/index.html|!_build/apidoc/**/*.html
+  - _build/**/*.html|!_build/genindex/index.html|!_build/reference/apidoc/**/*.html
   pipeline:
   - pyspelling.filters.html:
       comments: false

--- a/doc/explanation/security.md
+++ b/doc/explanation/security.md
@@ -61,7 +61,7 @@ varying key lengths of RSA, DSA, ECDSA, ECDH and EdDSA.
 ### Cryptographic technology exposed to the user
 
 Netplan allows to configure certain cryptographic technology that can be
-described in its {doc}`netplan-yaml`. Notable settings include the
+described in its {doc}`../reference/netplan-yaml`. Notable settings include the
 {ref}`yaml-auth` block, e.g. `auth.password` can be used configure `WPA-PSK` or
 `WPA-EAP` secrets, which can also be a special `hash:...` value for
 `wpa_supplicant`. The `auth.method` field controls the technology, such as


### PR DESCRIPTION
## Description

* Fix path in spellcheck exceptions to allow spellcheck to pass.
* Fix link path.
